### PR TITLE
reenabled windows build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
# Description

feat: https://github.com/vexxhost/terraform-provider-uptimerobot/pull/24

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
